### PR TITLE
Set CLASSPATH to empty for JRuby

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1399,6 +1399,9 @@ async function run() {
     if (platform === 'windows-latest') {
       rubyPrefix = await windows.downloadExtractAndSetPATH(ruby)
     } else {
+      if (ruby.startsWith('jruby')) {
+        core.exportVariable('CLASSPATH', '')
+      }
       rubyPrefix = await downloadAndExtract(platform, ruby)
       core.addPath(`${rubyPrefix}/bin`)
     }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ async function run() {
     if (platform === 'windows-latest') {
       rubyPrefix = await windows.downloadExtractAndSetPATH(ruby)
     } else {
+      if (ruby.startsWith('jruby')) {
+        core.exportVariable('CLASSPATH', '')
+      }
       rubyPrefix = await downloadAndExtract(platform, ruby)
       core.addPath(`${rubyPrefix}/bin`)
     }


### PR DESCRIPTION
This sets CLASSPATH to an empty string before the download/installation.

Not sure whether this is considered a valid thing to do, but the 'Ruby Info' step in https://github.com/MSP-Greg/use-ruby-action-info/runs/381796430 completes with it.

Using yarn now.