### PR TITLE
Use SSD drive for Windows Ruby location

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4826,9 +4826,11 @@ async function install(platform, ruby) {
   }
   const base = url.slice(url.lastIndexOf('/') + 1, url.length - '.7z'.length)
 
+  const drv = (process.env['GITHUB_WORKSPACE'] || 'C')[0]
+
   const downloadPath = await tc.downloadTool(url)
-  await exec.exec(`7z x ${downloadPath} -xr!${base}\\share\\doc -oC:\\`)
-  const rubyPrefix = `C:\\${base}`
+  await exec.exec(`7z x ${downloadPath} -xr!${base}\\share\\doc -o${drv}:\\`)
+  const rubyPrefix = `${drv}:\\${base}`
 
   const [hostedRuby, msys2] = await linkMSYS2()
   const newPath = setupPath(msys2, rubyPrefix)

--- a/windows.js
+++ b/windows.js
@@ -25,9 +25,11 @@ export async function install(platform, ruby) {
   }
   const base = url.slice(url.lastIndexOf('/') + 1, url.length - '.7z'.length)
 
+  const drv = (process.env['GITHUB_WORKSPACE'] || 'C')[0]
+
   const downloadPath = await tc.downloadTool(url)
-  await exec.exec(`7z x ${downloadPath} -xr!${base}\\share\\doc -oC:\\`)
-  const rubyPrefix = `C:\\${base}`
+  await exec.exec(`7z x ${downloadPath} -xr!${base}\\share\\doc -o${drv}:\\`)
+  const rubyPrefix = `${drv}:\\${base}`
 
   const [hostedRuby, msys2] = await linkMSYS2()
   const newPath = setupPath(msys2, rubyPrefix)


### PR DESCRIPTION
From a bit of quick research, the systems used for Actions have both a HD and an SSD.  Added code to place the Windows Ruby on the SSD, assuming it is `d:`